### PR TITLE
방명록 전체 가져오기 페이지네이션 구현

### DIFF
--- a/src/common/errors/error-codes.ts
+++ b/src/common/errors/error-codes.ts
@@ -5,6 +5,30 @@ export class ErrorCodes {
   ) {}
 
   // 방명록 관련 에러
+  static readonly PAGE_MUST_BE_NUMBER = new ErrorCodes(
+    'page는 양수여야 합니다.',
+    400,
+  );
+
+  static readonly PAGE_MUST_BE_AT_LEAST_ONE = new ErrorCodes(
+    'page는 1 이상이어야 합니다.',
+    400,
+  );
+
+  static readonly PAGE_LIMIT_MUST_BE_NUMBER = new ErrorCodes(
+    'size는 양수여야 합니다.',
+    400,
+  );
+
+  static readonly PAGE_LIMIT_MUST_BE_AT_LEAST_ONE = new ErrorCodes(
+    'size는 최소 1 이상이어야 합니다.',
+    400,
+  );
+
+  static readonly PAGE_LIMIT_MUST_BE_AT_MOST_TWENTY = new ErrorCodes(
+    'size는 최대 20 이하이어야 합니다.',
+    400,
+  );
   static readonly GUESTBOOK_NOT_FOUND = new ErrorCodes(
     '방명록을 찾을 수 없습니다.',
     404,

--- a/src/common/types/guestbooks.type.ts
+++ b/src/common/types/guestbooks.type.ts
@@ -30,3 +30,7 @@ export type TGuestbookData = Prisma.GuestBookGetPayload<{
     };
   };
 }>;
+
+export type TGuestbookResponse = Omit<TGuestbookData, 'user'> & {
+  hostNickname?: string;
+};

--- a/src/domains/guestbooks/guestbooks.dto.ts
+++ b/src/domains/guestbooks/guestbooks.dto.ts
@@ -1,4 +1,13 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+import { ErrorCodes } from 'src/common/errors/error-codes';
 
 export class CreateGuestbookDto {
   @IsString()
@@ -10,4 +19,29 @@ export class UpdateGuestbookDto {
   @IsString()
   @IsNotEmpty({ message: '방명록은 최소 1자 이상이어야 합니다.' })
   content: string;
+}
+
+export class PaginationQueryDto {
+  @Type(() => Number)
+  @IsInt({
+    message: ErrorCodes.PAGE_MUST_BE_NUMBER.message,
+  })
+  @IsOptional()
+  @Min(1, {
+    message: ErrorCodes.PAGE_MUST_BE_AT_LEAST_ONE.message,
+  })
+  page?: number = 1;
+
+  @Type(() => Number)
+  @IsInt({
+    message: ErrorCodes.PAGE_LIMIT_MUST_BE_NUMBER.message,
+  })
+  @IsOptional()
+  @Min(1, {
+    message: ErrorCodes.PAGE_LIMIT_MUST_BE_AT_LEAST_ONE.message,
+  })
+  @Max(20, {
+    message: ErrorCodes.PAGE_LIMIT_MUST_BE_AT_MOST_TWENTY.message,
+  })
+  limit?: number = 10;
 }


### PR DESCRIPTION
이슈 번호
- #21 

작업 상세
1. 페이지네이션 기능 추가
   - PaginationQueryDto 클래스 생성으로 페이지네이션 쿼리 파라미터 정의
   - 방명록 서비스에 페이지네이션 로직 구현 (findAll 메서드 개선)
   - 컨트롤러에서 페이지네이션 쿼리 파라미터 처리

2. API 문서화 개선
   - Swagger 데코레이터를 사용한 API 설명 및 파라미터 문서화
   - 인증 요구사항 명시 (@ApiCookieAuth 추가)

3. 오류 처리 강화
   - 페이지네이션 관련 새로운 에러 코드 및 메시지 추가

4. 타입 정의 개선
   - TGuestbookResponse 타입 추가
   - 서비스 메서드의 반환 타입 명시