### PR TITLE
방명록 수정 기능 추가 및 코드 리팩토링

### DIFF
--- a/src/common/errors/error-codes.ts
+++ b/src/common/errors/error-codes.ts
@@ -38,4 +38,9 @@ export class ErrorCodes {
     '방명록 소유자만 접근할 수 있습니다.',
     403,
   );
+
+  static readonly GUESTBOOK_NO_IMAGE = new ErrorCodes(
+    '방명록에 이미지가 없습니다.',
+    400,
+  );
 }

--- a/src/common/types/guestbooks.type.ts
+++ b/src/common/types/guestbooks.type.ts
@@ -2,7 +2,7 @@ import { Prisma } from '@prisma/client';
 
 export interface TGuestbookSelect extends Prisma.GuestBookSelectScalar {
   createdAt: true;
-  imageUrl: true;
+  imageKey: true;
   userId: boolean;
   user: {
     select: {
@@ -17,7 +17,7 @@ export interface TGuestbookSelect extends Prisma.GuestBookSelectScalar {
 
 export type TGuestbookData = Prisma.GuestBookGetPayload<{
   include: {
-    imageUrl: true;
+    imageKey: true;
     createdAt: true;
     user: {
       select: {

--- a/src/database/prisma/migrations/20240713072114_/migration.sql
+++ b/src/database/prisma/migrations/20240713072114_/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `imageUrl` on the `GuestBook` table. All the data in the column will be lost.
+  - You are about to drop the column `avatarImageUrl` on the `UserProfile` table. All the data in the column will be lost.
+  - You are about to drop the column `homeImageUrl` on the `UserProfile` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[imageKey]` on the table `GuestBook` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[avatarImageKey]` on the table `UserProfile` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[homeImageKey]` on the table `UserProfile` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "GuestBook" DROP COLUMN "imageUrl",
+ADD COLUMN     "imageKey" TEXT;
+
+-- AlterTable
+ALTER TABLE "UserProfile" DROP COLUMN "avatarImageUrl",
+DROP COLUMN "homeImageUrl",
+ADD COLUMN     "avatarImageKey" TEXT,
+ADD COLUMN     "homeImageKey" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GuestBook_imageKey_key" ON "GuestBook"("imageKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserProfile_avatarImageKey_key" ON "UserProfile"("avatarImageKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserProfile_homeImageKey_key" ON "UserProfile"("homeImageKey");

--- a/src/database/prisma/schema.prisma
+++ b/src/database/prisma/schema.prisma
@@ -32,7 +32,7 @@ model GuestBook {
 
   visitorName String?
   content     String?
-  imageUrl    String?
+  imageKey    String? @unique
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -40,13 +40,13 @@ model GuestBook {
 }
 
 model UserProfile {
-  id       String @id
-  user     User   @relation(fields: [id], references: [id])
-  nickname String
+  id            String @id
+  user          User   @relation(fields: [id], references: [id])
+  nickname      String
   guestBookName String
 
-  avatarImageUrl String?
-  homeImageUrl    String?
+  avatarImageKey String? @unique
+  homeImageKey   String? @unique
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/domains/guestbooks/guestbooks.controller.ts
+++ b/src/domains/guestbooks/guestbooks.controller.ts
@@ -102,6 +102,17 @@ export class GuestbooksController {
     return this.guestbooksService.create(userId, imageFile, createGuestbookDto);
   }
 
+  @Put(':id/photo')
+  @UseInterceptors(FileInterceptor('imageFile'))
+  @Private('user')
+  updatePhoto(
+    @DAccount('user') user: User,
+    @Param('id') id: string,
+    @UploadedFile() imageFile: Express.Multer.File,
+  ) {
+    return this.guestbooksService.updatePhoto(id, user.id, imageFile);
+  }
+
   /**
    * @description: 방명록 작성
    */

--- a/src/domains/guestbooks/guestbooks.controller.ts
+++ b/src/domains/guestbooks/guestbooks.controller.ts
@@ -60,7 +60,7 @@ export class GuestbooksController {
     user: User,
   ) {
     const guestbooks: TGuestbookResponse[] =
-      await this.guestbooksService.findAll(
+      await this.guestbooksService.findGuestbooks(
         user.id,
         paginationQuery.page,
         paginationQuery.limit,
@@ -106,11 +106,11 @@ export class GuestbooksController {
    * @description: 방명록 작성
    */
   @Put(':id')
-  update(
+  updateMessage(
     @Param('id') id: string,
     @Body() updateGuestbookDto: UpdateGuestbookDto,
   ) {
-    return this.guestbooksService.update(id, updateGuestbookDto);
+    return this.guestbooksService.updateMessage(id, updateGuestbookDto);
   }
 
   /**

--- a/src/domains/guestbooks/guestbooks.exception.ts
+++ b/src/domains/guestbooks/guestbooks.exception.ts
@@ -12,3 +12,9 @@ export class GuestBookAccessDeniedException extends ServiceException {
     super(ErrorCodes.GUESTBOOK_ACCESS_DENIED);
   }
 }
+
+export class GuestBookNoImageException extends ServiceException {
+  constructor() {
+    super(ErrorCodes.GUESTBOOK_NO_IMAGE);
+  }
+}

--- a/src/domains/guestbooks/guestbooks.module.ts
+++ b/src/domains/guestbooks/guestbooks.module.ts
@@ -3,11 +3,12 @@ import { ConfigModule } from '@nestjs/config';
 import { S3Module } from 'src/storage/aws.module';
 import { S3Service } from 'src/storage/aws.service';
 import { GuestbooksController } from './guestbooks.controller';
+import { GuestbooksRepository } from './guestbooks.repository';
 import { GuestbooksService } from './guestbooks.service';
 
 @Module({
   imports: [S3Module, ConfigModule],
   controllers: [GuestbooksController],
-  providers: [GuestbooksService, S3Service],
+  providers: [GuestbooksService, S3Service, GuestbooksRepository],
 })
 export class GuestbooksModule {}

--- a/src/domains/guestbooks/guestbooks.repository.ts
+++ b/src/domains/guestbooks/guestbooks.repository.ts
@@ -1,0 +1,92 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { TGuestbookSelect } from 'src/common/types/guestbooks.type';
+import { PrismaService } from 'src/database/prisma/prisma.service';
+
+@Injectable()
+export class GuestbooksRepository {
+  private readonly GUESTBOOK_SELECT_FIELDS: TGuestbookSelect;
+
+  constructor(private readonly prismaService: PrismaService) {
+    this.GUESTBOOK_SELECT_FIELDS = {
+      id: true,
+      userId: true,
+      visitorName: true,
+      content: true,
+      imageKey: true,
+      createdAt: true,
+      user: {
+        select: {
+          userProfile: {
+            select: {
+              nickname: true,
+            },
+          },
+        },
+      },
+    };
+  }
+
+  async findMany(userId: string, skip: number, take: number) {
+    const guestbooks = await this.prismaService.guestBook.findMany({
+      select: this.GUESTBOOK_SELECT_FIELDS,
+      where: {
+        userId,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      skip,
+      take,
+    });
+
+    return guestbooks;
+  }
+
+  async count(userId: string) {
+    return await this.prismaService.guestBook.count({
+      where: { userId },
+    });
+  }
+
+  async create(data: Prisma.GuestBookUncheckedCreateInput) {
+    const createData = {
+      data,
+      select: this.GUESTBOOK_SELECT_FIELDS,
+    };
+
+    const createdGuestbook =
+      await this.prismaService.guestBook.create(createData);
+
+    return createdGuestbook;
+  }
+
+  async findUniqueBy(where: Prisma.GuestBookWhereUniqueInput) {
+    const guestbook = await this.prismaService.guestBook.findUnique({
+      where,
+      select: this.GUESTBOOK_SELECT_FIELDS,
+    });
+
+    return guestbook;
+  }
+
+  async updateOneBy(
+    where: Prisma.GuestBookWhereUniqueInput,
+    data: Partial<Prisma.GuestBookUpdateInput>,
+  ) {
+    const updatedGuestbook = await this.prismaService.guestBook.update({
+      select: this.GUESTBOOK_SELECT_FIELDS,
+      where,
+      data,
+    });
+
+    return updatedGuestbook;
+  }
+
+  async deleteOneBy(where: Prisma.GuestBookWhereUniqueInput) {
+    return await this.prismaService.guestBook.delete({
+      where,
+      select: this.GUESTBOOK_SELECT_FIELDS,
+    });
+  }
+}

--- a/src/domains/users/users.controller.ts
+++ b/src/domains/users/users.controller.ts
@@ -19,12 +19,12 @@ import { CookieOptions, Response } from 'express';
 import * as jwt from 'jsonwebtoken';
 
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
+import { ApiCreatedResponse, ApiOperation, ApiQuery } from '@nestjs/swagger';
 import { DAccount } from 'src/decorator/account.decorator';
 import { Private } from 'src/decorator/private.decorator';
 import { S3Service } from '../../storage/aws.service';
 import { EditProfileDto, SignUpKakaoDto } from './users.dto';
 import { UsersService } from './users.service';
-import { ApiCreatedResponse, ApiOperation, ApiQuery } from '@nestjs/swagger';
 
 @Controller('users')
 export class UsersController {
@@ -179,7 +179,7 @@ export class UsersController {
       homeImage: files?.homeImage?.pop(),
     };
 
-    const [avatarImagePath, homeImagePath] = await Promise.all([
+    const [avatarImageKey, homeImageKey] = await Promise.all([
       this.s3Service.uploadFile(avatarImage),
       this.s3Service.uploadFile(homeImage),
     ]);
@@ -187,8 +187,8 @@ export class UsersController {
     return await this.usersService.editProfile(
       user.id.toString(),
       dto,
-      avatarImagePath,
-      homeImagePath,
+      avatarImageKey,
+      homeImageKey,
     );
   }
 

--- a/src/domains/users/users.service.ts
+++ b/src/domains/users/users.service.ts
@@ -119,16 +119,16 @@ export class UsersService {
   ) {
     return await this.prismaService.userProfile.update({
       where: { id: userId },
-      data: { ...dto, avatarImageUrl: avatarImage, homeImageUrl: homeImage },
+      data: { ...dto, avatarImageKey: avatarImage, homeImageKey: homeImage },
     });
   }
 
   async deleteImage(userId: string, isAvatarImage: boolean) {
-    const fieldToUpdate = isAvatarImage ? 'avatarImageUrl' : 'homeImageUrl';
+    const imageKeyToUpdate = isAvatarImage ? 'avatarImageKey' : 'homeImageKey';
     await this.prismaService.userProfile.update({
       where: { id: userId },
       data: {
-        [fieldToUpdate]: null,
+        [imageKeyToUpdate]: null,
       },
     });
   }

--- a/src/storage/aws.service.ts
+++ b/src/storage/aws.service.ts
@@ -56,10 +56,8 @@ export class S3Service {
       ContentType: contentType,
     });
 
-    const awsRegion = this.configService.get('AWS_REGION');
-
     await this.s3.send(uploadCommand);
 
-    return `https://${this.bucketName}.s3.${awsRegion}.amazonaws.com/${key}`;
+    return key;
   }
 }

--- a/src/storage/aws.service.ts
+++ b/src/storage/aws.service.ts
@@ -1,4 +1,8 @@
-import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+  DeleteObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
@@ -59,5 +63,21 @@ export class S3Service {
     await this.s3.send(uploadCommand);
 
     return key;
+  }
+
+  async deleteFile(key?: string) {
+    if (!key) return false;
+
+    const deleteCommand = new DeleteObjectCommand({
+      Bucket: this.bucketName,
+      Key: key,
+    });
+
+    try {
+      await this.s3.send(deleteCommand);
+      return true;
+    } catch (error) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
# 이슈 번호
- #26 

# 작업 상세
## 1. 이미지 필드 값 리팩토링
- 스키마 내에서 이미지 필드 이름을 `~Url`에서 `~Key`로 수정
- 이를 통해 S3 객체 키 관리의 일관성 향상

## 2. S3 객체 삭제 기능 추가
- S3 서비스에 객체 삭제 메서드 구현
- 불필요한 이미지 파일 관리 기능 강화

## 3. 방명록 리포지토리 모듈 구현
- 데이터베이스 관련 로직을 `guestbooks.repository.ts`로 분리
- 서비스 로직과 데이터 접근 로직의 명확한 분리로 유지보수성 향상

## 4. 방명록 사진 수정 기능 추가
- 방명록 사진 수정을 위한 새로운 메서드를 서비스와 라우터에 구현
- 사용자 경험 개선 및 기능 확장