### PR TITLE
fix: 유저 컨트롤러 로그아웃 라우터 수정

### DIFF
--- a/src/domains/users/users.controller.ts
+++ b/src/domains/users/users.controller.ts
@@ -110,8 +110,7 @@ export class UsersController {
     description: '쿠키를 만료시켜 로그아웃합니다.',
   })
   async signOut(@Res({ passthrough: true }) response: Response) {
-    response.clearCookie('accessToken', this.cookieOptions);
-    response.status(204).send();
+    return response.clearCookie('accessToken', this.cookieOptions).status(204);
   }
 
   @Private('user')


### PR DESCRIPTION
이슈 번호
- #57 

작업 상세
- passthrough:true면 네스트 표준 응답 처리를 사용한다는 얘기고, send가 들어가면 headerSent 가 발생하기 때문에 send를 제거해야 함