### PR TITLE
fix: 유저 컨트롤러 로그아웃 라우터 수정

### DIFF
--- a/src/domains/users/users.controller.ts
+++ b/src/domains/users/users.controller.ts
@@ -110,7 +110,9 @@ export class UsersController {
     description: '쿠키를 만료시켜 로그아웃합니다.',
   })
   async signOut(@Res({ passthrough: true }) response: Response) {
-    return response.clearCookie('accessToken', this.cookieOptions).status(204);
+    response.clearCookie('accessToken', this.cookieOptions);
+    response.status(204);
+    return;
   }
 
   @Private('user')


### PR DESCRIPTION
- status 메서드의 리턴 값은 this(Response 객체 자체)임
- return void 를 통해서 명시적으로 NestJS 런타임 시스템에 응답 처리 위임