### PR TITLE
방명록 API 문서 완성

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,22 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
+    "plugins": [
+      {
+        "name": "@nestjs/swagger",
+        "options": {
+          "classValidatorShim": false,
+          "introspectComments": true,
+          "dtoFileNameSuffix": [".dto.ts"],
+          "controllerFileNameSuffix": [".controller.ts"],
+          "swaggerGenerationOptions": {
+            "tagFilters": ["nestjs", "swagger"],
+            "controllerNameSuffix": "Controller",
+            "addDefaultApiTags": true
+          }
+        }
+      }
+    ],
     "deleteOutDir": true
   }
 }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,10 +1,15 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { AppService } from './app.service';
 
+@ApiTags('App')
 @Controller()
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
+  /**
+   * 헬스체크
+   */
   @Get()
   getHello(): string {
     return this.appService.getHello();

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from '@nestjs/common';
 @Injectable()
 export class AppService {
   getHello(): string {
-    return 'Hello World!';
+    return 'OK';
   }
 }

--- a/src/domains/guestbooks/guestbooks.controller.ts
+++ b/src/domains/guestbooks/guestbooks.controller.ts
@@ -12,12 +12,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import {
-  ApiCookieAuth,
-  ApiOperation,
-  ApiQuery,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiCookieAuth, ApiTags } from '@nestjs/swagger';
 import { User } from '@prisma/client';
 import { TGuestbookResponse } from 'src/common/types/guestbooks.type';
 import { DAccount } from 'src/decorator/account.decorator';
@@ -40,25 +35,11 @@ export class GuestbooksController {
   ) {}
 
   /**
-   * @description: 방명록 목록 조회
+   * 방명록 목록을 조회합니다.
    */
   @Get()
   @Private('user')
-  @ApiOperation({
-    summary: '방명록 목록 조회',
-    description: '방명록 목록을 조회합니다.',
-  })
   @ApiCookieAuth()
-  @ApiQuery({
-    name: 'page',
-    required: false,
-    type: Number,
-  })
-  @ApiQuery({
-    name: 'size',
-    required: false,
-    type: Number,
-  })
   async findAll(
     @Query()
     paginationQuery: PaginationQueryDto,
@@ -76,7 +57,7 @@ export class GuestbooksController {
   }
 
   /**
-   * @description: 방명록 개수 조회
+   * 전체 방명록의 개수를 조회합니다.
    */
   @Get('count')
   @Private('user')
@@ -85,13 +66,16 @@ export class GuestbooksController {
   }
 
   /**
-   * @description: 방명록 단건 조회
+   * 방명록을 조회합니다.
    */
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.guestbooksService.findOne(id);
   }
 
+  /**
+   * 방명록의 사진 업로드하기 위한 사전 서명된 URL을 조회합니다.
+   */
   @Get('presigned-url/:id')
   @Private('user')
   getPresignedUrl(@Param('id') id: string) {
@@ -99,7 +83,7 @@ export class GuestbooksController {
   }
 
   /**
-   * @description: 방명록 생성
+   * 방명록을 생성합니다.
    */
   @Post()
   @Private('user')
@@ -117,6 +101,9 @@ export class GuestbooksController {
     return guestbook;
   }
 
+  /**
+   * 방명록 사진을 업로드합니다.
+   */
   @Put(':id/photo')
   @UseInterceptors(FileInterceptor('imageFile'))
   @Private('user')
@@ -129,7 +116,7 @@ export class GuestbooksController {
   }
 
   /**
-   * @description: 방명록 작성
+   * 방명록 메시지를 수정합니다.
    */
   @Put(':id')
   updateMessage(
@@ -140,7 +127,7 @@ export class GuestbooksController {
   }
 
   /**
-   * @description: 방명록 삭제
+   * 방명록을 삭제합니다.
    */
   @Delete(':id')
   @Private('user')

--- a/src/domains/users/users.controller.ts
+++ b/src/domains/users/users.controller.ts
@@ -20,13 +20,19 @@ import { CookieOptions, Response } from 'express';
 import * as jwt from 'jsonwebtoken';
 
 import { FileFieldsInterceptor } from '@nestjs/platform-express';
-import { ApiCreatedResponse, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import {
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
 import { DAccount } from 'src/decorator/account.decorator';
 import { Private } from 'src/decorator/private.decorator';
 import { StorageService } from 'src/storage/storage.service';
 import { EditProfileDto, SignUpKakaoDto } from './users.dto';
 import { UsersService } from './users.service';
 
+@ApiTags('유저 API')
 @Controller('users')
 export class UsersController {
   private jwtSecret: string;


### PR DESCRIPTION
이슈 번호: #61 

- 작업 요역
1. nest-cli.json에 Swagger CLI 플러그인 설정 추가
2. GuestbooksController의 API 문서화 방식 개선
3. UsersController에 Api태그 추가
4. App 컨트롤러 문서화

- 작업 상세
1. Swagger CLI 플러그인 설정
  - nest-cli.json 파일에 @nestjs/swagger 플러그인 옵션 추가
  - 자동 API 문서화 기능 활성화
  - DTO와 컨트롤러 파일 접미사 지정
  - 기본 ApiTags 자동 생성 설정

2. GuestbooksController 리팩토링
  - @ApiOperation 데코레이터 제거 및 JSDoc 주석으로 대체
  - 불필요한 @ApiQuery 데코레이터 제거
  - 각 API 엔드포인트의 설명을 더 명확하고 간결하게 수정
  - 누락된 메서드(presigned-url)에 대한 설명 추가