### PR TITLE
프로필 이미지 업데이트 코드 리팩토링

### DIFF
--- a/src/domains/users/components/users-storage.component.ts
+++ b/src/domains/users/components/users-storage.component.ts
@@ -9,7 +9,7 @@ export class UsersStorageComponent {
     private readonly storageService: StorageService,
   ) {}
 
-  async putUserProfileImages(
+  private async uploadProfileImages(
     images: TUserProfileImages,
   ): Promise<{ avatarImageKey?: string; homeImageKey?: string }> {
     const { avatarImage, homeImage } = {
@@ -25,16 +25,30 @@ export class UsersStorageComponent {
     return { avatarImageKey, homeImageKey };
   }
 
-  async deleteUserProfileImage(key?: string | null) {
-    if (!key) return;
-    await this.storageService.deleteFile(key);
+  private async deleteProfileImages(...keys: (string | null | undefined)[]) {
+    const validKeys = keys.filter((k): k is string => k != null);
+
+    await Promise.all(
+      validKeys.map((key) => this.storageService.deleteFile(key)),
+    );
   }
 
-  async deleteUserProfileImages(...keys: (string | null | undefined)[]) {
-    const deletionPromises = keys
-      .filter((k): k is string => k !== null && k !== undefined)
-      .map((key) => this.storageService.deleteFile(key));
+  async updateProfileImages(
+    imageKeys: {
+      avatarImageKey?: string | null;
+      homeImageKey?: string | null;
+    },
+    newProfileImages: TUserProfileImages,
+  ): Promise<{ newAvatarImageKey?: string; newHomeImageKey?: string }> {
+    this.deleteProfileImages(imageKeys.avatarImageKey, imageKeys.homeImageKey);
 
-    await Promise.all(deletionPromises);
+    const { avatarImageKey: newAvatarImageKey, homeImageKey: newHomeImageKey } =
+      await this.uploadProfileImages(newProfileImages);
+
+    return { newAvatarImageKey, newHomeImageKey };
+  }
+
+  async deleteUserProfileImage(key?: string | null) {
+    await this.storageService.deleteFile(key ?? '');
   }
 }

--- a/src/domains/users/users.service.ts
+++ b/src/domains/users/users.service.ts
@@ -43,18 +43,19 @@ export class UsersService {
   async editProfile(
     userId: string,
     dto: EditProfileDto,
-    files: TUserProfileImages,
+    profileImages: TUserProfileImages,
   ) {
     const { avatarImageKey, homeImageKey } =
       await this.usersRepositoryComponent.getOneProfile(userId);
 
-    await this.usersStorageComponent.deleteUserProfileImages(
-      avatarImageKey,
-      homeImageKey,
-    );
-
-    const { avatarImageKey: newAvatarImageKey, homeImageKey: newHomeImageKey } =
-      await this.usersStorageComponent.putUserProfileImages(files);
+    const { newAvatarImageKey, newHomeImageKey } =
+      await this.usersStorageComponent.updateProfileImages(
+        {
+          avatarImageKey,
+          homeImageKey,
+        },
+        profileImages,
+      );
 
     return await this.usersRepositoryComponent.editProfile(userId, {
       ...dto,
@@ -71,7 +72,6 @@ export class UsersService {
       await this.usersRepositoryComponent.getOneProfile(userId);
 
     await this.usersStorageComponent.deleteUserProfileImage(imageKeyToDelete);
-
     await this.usersRepositoryComponent.editProfile(userId, {
       [imageKey]: null,
     });


### PR DESCRIPTION
이슈 번호: #69 

작업 상세
- users.service.ts:
  - 프로필 이미지 업데이트 로직을 단일 메서드로 통합
  - 매개변수 이름 'files'를 'profileImages'로 변경하여 명확한 의미 전달

- users-storage.component.ts:
  - 'putUserProfileImages' 메서드를 'uploadProfileImages'로 이름 변경 및 private으로 설정
  - 'deleteUserProfileImages' 메서드를 'deleteProfileImages'로 개선하고 private으로 설정
  - 새로운 'updateProfileImages' 메서드 추가하여 이미지 삭제 및 업로드 프로세스 통합
  - 'deleteUserProfileImage' 메서드 간소화